### PR TITLE
feat: expose PID_MAX_I_TERM in config.h and add 3 new IDN fields

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -44,7 +44,7 @@ PROJECT_NAME           = "Motor Driver Evaluation Kit"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "NEVB-MTR1-t01-1.2.1"
+PROJECT_NUMBER         = "NEVB-MTR1-t01-1.3.0"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 -----------------
 # NEVC-MTR1-t01: Trapezoidal control of brushless DC (BLDC) motors using hall effect sensors firmware for NEVB-MTR1 series evaluation kit 
 
-![Version](https://img.shields.io/badge/Version-1.2.1-blue) [![License - MIT/X Consortium](https://img.shields.io/badge/License-MIT%2FX%20Consortium-green)](https://github.com/Nexperia/NEVB-MTR1-t01/blob/main/LICENSE)
+![Version](https://img.shields.io/badge/Version-1.3.0-blue) [![License - MIT/X Consortium](https://img.shields.io/badge/License-MIT%2FX%20Consortium-green)](https://github.com/Nexperia/NEVB-MTR1-t01/blob/main/LICENSE)
 
 ## Introduction
 

--- a/main/config.h
+++ b/main/config.h
@@ -566,6 +566,34 @@
 #define PID_K_D 0
 
 /*!
+   \brief Maximum PID Integrator Sum (Anti-Windup Limit)
+
+   This macro sets the maximum absolute value of the accumulated error sum
+   inside the PID integrator. When the sum would exceed this limit it is
+   clamped, preventing integrator wind-up.
+
+   The i-term contribution to the output is approximately:
+   \f[ \text{i-term} \approx \frac{\text{PID\_MAX\_I\_TERM} \times
+      \text{PID\_K\_I}}{1000} \f]
+   so the default of 100000 with the default \ref PID_K_I of 10 limits the
+   integrator's output contribution to ~1000, which is already well above
+   the \ref PID_OUTPUT_MAX ceiling and ensures fast unwind after a
+   disturbance.
+
+   The absolute upper bound is \f$2\,147\,418\,113\f$ (MAX_LONG −
+   2 × MAX_INT) imposed by the underlying 32-bit data types.
+
+   \note This parameter is applicable when \ref SPEED_CONTROL_METHOD is set to
+   \ref SPEED_CONTROL_CLOSED_LOOP.
+
+   \todo Reduce to tighten anti-windup or increase if integral action is
+         too slow to recover after large speed steps.
+
+   \see PID_K_I, PID_OUTPUT_MAX, SPEED_CONTROL_METHOD
+*/
+#define PID_MAX_I_TERM 100000L
+
+/*!
    \brief Maximum PID Controller Output (Only for Closed Loop)
 
    This macro sets the ceiling on the value returned by the PID controller
@@ -1311,6 +1339,16 @@ Divide by frequency to get duration.
 #if ((EMULATE_HALL == TRUE) && (SPEED_CONTROL_METHOD == SPEED_CONTROL_CLOSED_LOOP))
 #error "Invalid combination of EMULATE_HALL and SPEED_CONTROL_METHOD"
 #endif
+
+/*!
+   \brief PID integrator clamp value passed to the PID controller.
+
+   Translates the user-settable \ref PID_MAX_I_TERM into the \c MAX_I_TERM
+   symbol consumed by \ref pid.h. The guard ensures that if \c pid.h is ever
+   compiled without \ref config.h in scope it falls back to its own safe
+   default.
+*/
+#define MAX_I_TERM PID_MAX_I_TERM
 
 /** @} */
 

--- a/main/pid.cpp
+++ b/main/pid.cpp
@@ -18,6 +18,8 @@
 
  ******************************************************************************/
 
+// Include motor config (provides MAX_I_TERM via PID_MAX_I_TERM)
+#include "config.h"
 // Include PID header
 #include "pid.h"
 

--- a/main/pid.h
+++ b/main/pid.h
@@ -78,19 +78,24 @@ typedef struct pidData
 
 /*! \brief Maximum value of the I-term.
 
-    This limits the maximum positive or negative value of the I-term. Changing
-    this value leads to a different integral anti-windup limit. Do not increase
-    this value from its default, as it is already at the limit of the underlying
-    data types.
+    This limits the maximum positive or negative value of the I-term, providing
+    integral anti-windup. Prefer setting \ref PID_MAX_I_TERM in \ref config.h
+    to override this value. The fallback here is the maximum safe value given
+    the underlying 32-bit data types.
 */
+#ifndef MAX_I_TERM
 #define MAX_I_TERM (MAX_LONG - (2 * (int32_t)MAX_INT))
+#endif
 
 // Boolean values
 //! FALSE constant.
+#ifndef FALSE
 #define FALSE 0
-
+#endif
 //! TRUE constant.
+#ifndef TRUE
 #define TRUE (!FALSE)
+#endif
 
 // Function prototypes
 void PIDInit(int16_t p_factor, int16_t i_factor, int16_t d_factor, pidData_t *pid);

--- a/main/scpi.cpp
+++ b/main/scpi.cpp
@@ -192,6 +192,12 @@ static void ScpiCoreIdnQ(SCPI_C commands, SCPI_P parameters, Stream &interface)
     interface.print((unsigned long)WAIT_FOR_BOARD, HEX);
     interface.print('-');
     interface.print((unsigned long)REMOTE_DEBUG_MODE, HEX);
+    interface.print('-');
+    interface.print((unsigned long)PID_MAX_I_TERM, HEX);
+    interface.print('-');
+    interface.print((unsigned long)PID_OUTPUT_MAX, HEX);
+    interface.print('-');
+    interface.print((unsigned long)VBUS_MIN_THRESHOLD, HEX);
     interface.print(F(","));
     interface.println(F(SCPI_IDN_FIRMWARE_VERSION));
 }

--- a/main/scpi.h
+++ b/main/scpi.h
@@ -284,10 +284,13 @@ void ScpiInput(Stream &interface);
      | 23    | `VBUS_RBOTTOM`                  | VBUS divider bottom resistor (Ω)            |
      | 24    | `WAIT_FOR_BOARD`                | Wait for inverter board enable (0/1)        |
      | 25    | `REMOTE_DEBUG_MODE`             | Remote debug mode enable (0/1)              |
+     | 26    | `PID_MAX_I_TERM`                | PID integrator anti-windup limit            |
+     | 27    | `PID_OUTPUT_MAX`                | PID output ceiling (closed loop)            |
+     | 28    | `VBUS_MIN_THRESHOLD`            | Minimum VBUS ADC count for motor operation  |
 
      Example response:
      ```
-     NEXPERIA,NEVB-MTR1-xx,8-4E20-15E-0-C8-1770-1-14-9C4-32-FA0-133-19A-1-0-C8-1-190-64-A-1-0-186A0-1838-1-0,NEVC-MTR1-t01-1.2.1
+     NEXPERIA,NEVB-MTR1-xx,8-4E20-15E-0-C8-1770-1-14-9C4-32-FA0-133-19A-1-0-C8-1-190-64-A-1-0-186A0-1838-1-0-186A0-C8-60,NEVC-MTR1-t01-1.2.1
      ```
 
      \subsection scpi_commands_required Required SCPI Commands

--- a/main/scpi.h
+++ b/main/scpi.h
@@ -290,7 +290,7 @@ void ScpiInput(Stream &interface);
 
      Example response:
      ```
-     NEXPERIA,NEVB-MTR1-xx,8-4E20-15E-0-C8-1770-1-14-9C4-32-FA0-133-19A-1-0-C8-1-190-64-A-1-0-186A0-1838-1-0-186A0-C8-60,NEVC-MTR1-t01-1.2.1
+     NEXPERIA,NEVB-MTR1-xx,8-4E20-15E-0-C8-1770-1-14-9C4-32-FA0-133-19A-1-0-C8-1-190-64-A-1-0-186A0-1838-1-0-186A0-C8-60,NEVC-MTR1-t01-1.3.0
      ```
 
      \subsection scpi_commands_required Required SCPI Commands

--- a/main/scpi_config.h
+++ b/main/scpi_config.h
@@ -119,7 +119,7 @@
  * \ref SCPI_IDN_FIRMWARE_VERSION automatically via C string-literal concatenation.
  * Format: "MAJOR.MINOR.PATCH" (e.g. "1.1.0")
  */
-#define FIRMWARE_VERSION "1.2.1"
+#define FIRMWARE_VERSION "1.3.0"
 
 /*! \def SCPI_IDN_FIRMWARE_VERSION
  * \brief Firmware version identification string for the `*IDN?` command.


### PR DESCRIPTION
## Summary
- Add `PID_MAX_I_TERM` (default 100000) to the user-settable PID section in `config.h` — controls the integrator anti-windup clamp
- Translate it to `MAX_I_TERM` in DerivedDefines so `pid.h` picks it up; `pid.h` falls back to its original formula if compiled without `config.h`
- Guard `FALSE`/`TRUE` in `pid.h` with `#ifndef` to prevent redefinition warnings; add `#include "config.h"` to `pid.cpp`
- Extend `*IDN?` response with three new trailing fields (indices 26–28): `PID_MAX_I_TERM`, `PID_OUTPUT_MAX`, `VBUS_MIN_THRESHOLD`