### PR TITLE
fix: remove factor-of-1000 discontinuity in PID integrator clamp

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -44,7 +44,7 @@ PROJECT_NAME           = "Motor Driver Evaluation Kit"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "NEVB-MTR1-t01-1.3.0"
+PROJECT_NUMBER         = "NEVB-MTR1-t01-1.3.1"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 -----------------
 # NEVC-MTR1-t01: Trapezoidal control of brushless DC (BLDC) motors using hall effect sensors firmware for NEVB-MTR1 series evaluation kit 
 
-![Version](https://img.shields.io/badge/Version-1.3.0-blue) [![License - MIT/X Consortium](https://img.shields.io/badge/License-MIT%2FX%20Consortium-green)](https://github.com/Nexperia/NEVB-MTR1-t01/blob/main/LICENSE)
+![Version](https://img.shields.io/badge/Version-1.3.1-blue) [![License - MIT/X Consortium](https://img.shields.io/badge/License-MIT%2FX%20Consortium-green)](https://github.com/Nexperia/NEVB-MTR1-t01/blob/main/LICENSE)
 
 ## Introduction
 

--- a/main/pid.cpp
+++ b/main/pid.cpp
@@ -75,23 +75,22 @@ uint16_t PIDController(int16_t setPoint, int16_t processValue, pidData_t *pid_st
     pid_st->p_term = pid_st->P_Factor * error / 1000;
   }
 
-  // Calculate "I" term and limit integral runaway
+  // Calculate "I" term and limit integral runaway.
+  // i_term is always derived from sumError so the clamp is continuous.
   temp = pid_st->sumError + error;
   if (temp > pid_st->maxSumError)
   {
-    pid_st->i_term = MAX_I_TERM;
     pid_st->sumError = pid_st->maxSumError;
   }
   else if (temp < -pid_st->maxSumError)
   {
-    pid_st->i_term = -MAX_I_TERM;
     pid_st->sumError = -pid_st->maxSumError;
   }
   else
   {
     pid_st->sumError = temp;
-    pid_st->i_term = pid_st->I_Factor * pid_st->sumError / 1000;
   }
+  pid_st->i_term = pid_st->I_Factor * pid_st->sumError / 1000;
 
 #if (PID_K_D_ENABLE == TRUE)
   // Calculate "D" term

--- a/main/scpi.h
+++ b/main/scpi.h
@@ -290,7 +290,7 @@ void ScpiInput(Stream &interface);
 
      Example response:
      ```
-     NEXPERIA,NEVB-MTR1-xx,8-4E20-15E-0-C8-1770-1-14-9C4-32-FA0-133-19A-1-0-C8-1-190-64-A-1-0-186A0-1838-1-0-186A0-C8-60,NEVC-MTR1-t01-1.3.0
+     NEXPERIA,NEVB-MTR1-xx,8-4E20-15E-0-C8-1770-1-14-9C4-32-FA0-133-19A-1-0-C8-1-190-64-A-1-0-186A0-1838-1-0-186A0-C8-60,NEVC-MTR1-t01-1.3.1
      ```
 
      \subsection scpi_commands_required Required SCPI Commands

--- a/main/scpi_config.h
+++ b/main/scpi_config.h
@@ -119,7 +119,7 @@
  * \ref SCPI_IDN_FIRMWARE_VERSION automatically via C string-literal concatenation.
  * Format: "MAJOR.MINOR.PATCH" (e.g. "1.1.0")
  */
-#define FIRMWARE_VERSION "1.3.0"
+#define FIRMWARE_VERSION "1.3.1"
 
 /*! \def SCPI_IDN_FIRMWARE_VERSION
  * \brief Firmware version identification string for the `*IDN?` command.


### PR DESCRIPTION
## Summary

- The clamped branches of the I-term calculation assigned `i_term = MAX_I_TERM` directly, while the normal branch used `i_term = I_Factor * sumError / 1000` — a 1000× mismatch at the clamp boundary
- This caused the duty cycle to jump discontinuously (e.g. 39% → 78%) whenever `sumError` hit `maxSumError`, producing visible oscillation
- Fix: always derive `i_term` from `sumError` after the clamp so the formula is identical in every path

## Test plan

- [x] Set `PID_MAX_I_TERM = 100000` and confirm no duty cycle oscillation at or near the integrator limit
- [x] Verify motor starts and runs smoothly under closed-loop speed control
- [x] Confirm `*IDN?` firmware version field reads `1.3.1`